### PR TITLE
Whitelist services that access CAS based on service hosts

### DIFF
--- a/lib/casserver/server.rb
+++ b/lib/casserver/server.rb
@@ -297,7 +297,7 @@ module CASServer
       if !service_allowed?(@service)
         $LOG.warn("The application you attempted to authenticate to is not authorized to use CAS. #{@service}")
         @message = {:type => 'mistake', :message => "The application you attempted to authenticate to is not authorized to use CAS."}
-        status 401
+        status 422
         return render @template_engine, :login
       end
 

--- a/rubycas-server.gemspec
+++ b/rubycas-server.gemspec
@@ -36,7 +36,7 @@ $gemspec = Gem::Specification.new do |s|
   s.add_development_dependency("capybara", '1.1.2')
   s.add_development_dependency("rspec")
   s.add_development_dependency("rspec-core")
-  s.add_development_dependency("rake", "0.8.7")
+  s.add_development_dependency("rake", "~> 10.4.2")
   s.add_development_dependency("sqlite3", "~> 1.3.1")
   s.add_development_dependency("appraisal", "~> 0.4.1")
   s.add_development_dependency("guard", "~> 1.4.0")

--- a/spec/casserver/utils_spec.rb
+++ b/spec/casserver/utils_spec.rb
@@ -11,13 +11,13 @@ describe CASServer::Utils, '#log_controller_action(controller, params)' do
   let(:params_with_password_filtered) { { 'password' => '******' } }
 
   it 'should log the controller action' do
-    $LOG.should_receive(:debug).with 'Processing application::instance_eval {}'
+    $LOG.should_receive(:debug).with 'Processing application::instance_exec {}'
 
     subject.log_controller_action('application', params)
   end
 
   it 'should filter password parameters in the log' do
-    $LOG.should_receive(:debug).with "Processing application::instance_eval #{params_with_password_filtered.inspect}"
+    $LOG.should_receive(:debug).with "Processing application::instance_exec #{params_with_password_filtered.inspect}"
 
     subject.log_controller_action('application', params_with_password)
   end

--- a/spec/config/default_config.yml
+++ b/spec/config/default_config.yml
@@ -8,13 +8,13 @@ port: 6543
 #   adapter: mysql
 #   database: casserver
 #   username: root
-#   password: 
+#   password:
 #   host: localhost
 #   reconnect: true
 database:
  adapter: sqlite3
  database: spec/casserver_spec.db
- 
+
 disable_auto_migrations: true
 
 quiet: true
@@ -51,3 +51,6 @@ enable_single_sign_out: true
 
 allowed_service_ips:
   - 127.0.0.0/24
+
+allowed_service_hosts:
+  - http://my.app.test


### PR DESCRIPTION
refer: https://github.com/TabDigital/backlog-platform-team/issues/3
- this will allow CAS to issue tickets only for allowed services
- gives error message _'The application you attempted to authenticate to is not authorized to use CAS'_ for a service which is not allowed.

@rprieto @deveshmaheshwari 
